### PR TITLE
✨ Apply all props from route definition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,29 @@ can also be used on server side rendering.
 :warning: This package is based on `react-router-dom` components and is required as a peer dependency, therefore, you
 can't use it (yet) on Native environment.
 
+* [Installation](#installation)
+* [Usage](#usage)
+* [Advanced usage](#advanced-usage)
+* [Configuration first usage](#configuration-first-usage)
+* [With react-router-config](#with-react-router-config)
+* [I18n (translated route paths)](#i18n-translated-route-paths)
+* [SSR](#ssr)
+* [API](#api)
+  * [NamedRouter](#namedrouter)
+  * [NamedLink](#namedlink)
+  * [NamedRedirect](#namedredirect)
+  * [NamedRoute](#namedroute-1)
+  * [NamedSwitch](#namedswitch-1)
+  * [Context API](#context-api)
+* [Contribute](#contribute)
+
 ## Installation
+
+Using [yarn](https://yarnpkg.com/):
+
+```shell
+$ yarn add react-named-router react-router-dom
+```
 
 Using [npm](https://www.npmjs.com/):
 
@@ -149,6 +171,32 @@ const MyComponent = () => {
 }
 ```
 
+## Configuration first usage
+
+`react-named-router` allows you to leverage the power of your routes configuration while maintaining high flexibility
+about where to render each route. The `NamedRoute` component will use all fields from the matching route to build its
+props:
+
+```jsx harmony
+// Configuration file
+const routes = [
+  { name: 'home', path: '/', component: Home },
+  { name: 'userDetails', path: '/users/:userId', exact: true, component: UserDetails },
+]
+
+// Component file
+const MyComponent = () => (
+  <>
+    <LeftContainer>
+      <NamedRoute name="home" />
+    </LeftContainer>
+    <RightContainer>
+      <NamedRoute name="userDetails" />
+    </RightContainer>
+  </>
+)
+```
+
 ## With `react-router-config`
 
 Since route configuration objects of `react-named-router` are based on `react-router-config` configuration objects, you
@@ -275,8 +323,7 @@ NamedRoute throw the following errors:
 
 - `Undefined route "$name"`: When the `to` prop does not match any route given to the `NamedRouter`.
 
-Also NamedRoute will pass an extra `route` prop to rendered component/render function so you can make some matching
-against route name or use `renderRoutes(route.routes)`.
+Also NamedRoute will forward all fields from matching route to Route component (`path`, `exact`, `component`).
 
 ### `NamedSwitch`
 

--- a/src/NamedRoute.tsx
+++ b/src/NamedRoute.tsx
@@ -25,7 +25,7 @@ const NamedRoute = ({
   const route = context.getRoute(name);
 
   return (
-    <Route {...otherProps} path={route.path} route={route}>
+    <Route {...otherProps} {...route}>
       {children}
     </Route>
   );

--- a/src/NamedRoute.tsx
+++ b/src/NamedRoute.tsx
@@ -25,7 +25,7 @@ const NamedRoute = ({
   const route = context.getRoute(name);
 
   return (
-    <Route {...otherProps} {...route}>
+    <Route {...route} {...otherProps}>
       {children}
     </Route>
   );

--- a/src/NamedRouter.tsx
+++ b/src/NamedRouter.tsx
@@ -9,7 +9,6 @@ import { BaseRoutingContext, buildRoutingContext, RoutingContext } from './utils
 export type NamedRouteConfig<T = object> = T & {
   name?: string;
   path?: string;
-  title?: string;
   routes?: NamedRouteConfig<T>[];
 }
 

--- a/src/__tests__/NamedRoute.spec.tsx
+++ b/src/__tests__/NamedRoute.spec.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import Enzyme, { mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { RouteProps, StaticRouter, StaticRouterProps } from 'react-router';
+import NamedRouter, { NamedRouteConfig } from '../NamedRouter';
+import NamedRoute from '../NamedRoute';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('NamedSwitch', () => {
+  it('should render only first matching route', () => {
+    // Given
+    const routerProps: StaticRouterProps = { location: '/foo' };
+    const routes: NamedRouteConfig<RouteProps>[] = [{
+      name: 'foo',
+      path: '/foo',
+      exact: true,
+      component: () => null,
+    }];
+
+    // When
+    const wrapper = mount((
+      <NamedRouter
+        routes={routes}
+        routerComponent={StaticRouter}
+        routerProps={routerProps}
+      >
+        <NamedRoute name="foo" />
+      </NamedRouter>
+    ));
+
+    // Then
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/__snapshots__/NamedRoute.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/NamedRoute.spec.tsx.snap
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NamedSwitch should render only first matching route 1`] = `
+<NamedRouter
+  routerComponent={[Function]}
+  routerProps={
+    Object {
+      "location": "/foo",
+    }
+  }
+  routes={
+    Array [
+      Object {
+        "component": [Function],
+        "exact": true,
+        "name": "foo",
+        "path": "/foo",
+      },
+    ]
+  }
+>
+  <StaticRouter
+    location="/foo"
+  >
+    <Router
+      history={
+        Object {
+          "action": "POP",
+          "block": [Function],
+          "createHref": [Function],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "pathname": "/foo",
+            "search": "",
+            "state": undefined,
+          },
+          "push": [Function],
+          "replace": [Function],
+        }
+      }
+      staticContext={Object {}}
+    >
+      <Route>
+        <NamedRoute
+          name="foo"
+        >
+          <Route
+            component={[Function]}
+            exact={true}
+            name="foo"
+            parents={Array []}
+            path="/foo"
+            regex={/\\^\\\\/foo\\\\/\\?\\$/}
+          >
+            <component
+              history={
+                Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/foo",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                }
+              }
+              location={
+                Object {
+                  "hash": "",
+                  "pathname": "/foo",
+                  "search": "",
+                  "state": undefined,
+                }
+              }
+              match={
+                Object {
+                  "isExact": true,
+                  "params": Object {},
+                  "path": "/foo",
+                  "url": "/foo",
+                }
+              }
+              staticContext={Object {}}
+            />
+          </Route>
+        </NamedRoute>
+      </Route>
+    </Router>
+  </StaticRouter>
+</NamedRouter>
+`;

--- a/src/__tests__/__snapshots__/NamedSwitch.spec.tsx.snap
+++ b/src/__tests__/__snapshots__/NamedSwitch.spec.tsx.snap
@@ -84,15 +84,10 @@ exports[`NamedSwitch should render only first matching route 1`] = `
                   "state": undefined,
                 }
               }
+              name="bar"
+              parents={Array []}
               path="/foo/bar"
-              route={
-                Object {
-                  "name": "bar",
-                  "parents": Array [],
-                  "path": "/foo/bar",
-                  "regex": /\\^\\\\/foo\\\\/bar\\\\/\\?\\$/,
-                }
-              }
+              regex={/\\^\\\\/foo\\\\/bar\\\\/\\?\\$/}
             />
           </NamedRoute>
         </NamedSwitch>


### PR DESCRIPTION
Hi,

If we destructure `route` to apply all the props set in the route definition, it allow us to call the route only with its name.

Example: 

```jsx
// In def:
[
	{ name:'foo', path: '/foo/bar', exact: true, component: Baz }
]

// In app:
<NamedRoute name="foo">
```

It can be the perfect mix between react-router-config and standard routing.

I'll update the tests if you ok with merging that.

Thanks!
Matt'